### PR TITLE
Fix missing backend route and add project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Este proyecto contiene un MVP funcional dividido en:
 - `backend/`: API en Express para procesar historias
 - `frontend/`: Interfaz en Next.js + Tailwind
 
+El backend expone la ruta `POST /parse` que por ahora devuelve escenas de
+ejemplo definidas en `backend/data/story-mock.json`. El frontend consume dicha
+API para mostrar las escenas generadas.
+
 ## Uso
 
 1. Rellena los archivos `.env` en `backend/` y `frontend/`

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "storyteller-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/backend/routes/parse.js
+++ b/backend/routes/parse.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const scenes = require('../data/story-mock.json');
+
+// For the MVP, simply return mock scenes regardless of input
+router.post('/', (req, res) => {
+  res.json(scenes);
+});
+
+module.exports = router;

--- a/frontend/data/story-mock.json
+++ b/frontend/data/story-mock.json
@@ -1,0 +1,12 @@
+
+[
+  {
+    "scene": 1,
+    "setting": "La cima de una montaña flotante",
+    "characters": ["Chica", "Espíritu"],
+    "actions": "El espíritu se le aparece y le ofrece una decisión.",
+    "dialogues": [
+      { "speaker": "Espíritu", "line": "¿Quieres quedarte o saltar al vacío y descubrir tu destino?" }
+    ]
+  }
+]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "storyteller-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.4.7",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.3.0",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.13"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve"
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add `POST /parse` route to return mock scenes
- include backend `package.json`
- create frontend `package.json`, TypeScript and Tailwind configs
- add example scene data for the frontend
- document the new parse route in `README`

## Testing
- `node backend/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_684dd1dc6720832aa3b42b8eb8db5631